### PR TITLE
Remove print header and footer

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -510,6 +510,14 @@ hr.hidden {
   @page {
     size: auto;
     /* padding: var(--space-medium); */
+    margin: 0mm; /* This deletes the margin where the header and footers are written */
+  }
+  html {
+    background-color: #FFFFFF; 
+    margin: 0mm;  /* this affects the margin on the html before sending to printer */
+  }
+  body {
+    margin: 15mm; /* margin you want for the content */
   }
   main {
     padding: 0;


### PR DESCRIPTION
Quand on imprime le courrier, le navigateur ajoute des headers/footer par défaut.
Cette PR permet de supprimer ces headers, en revanche c'est vite problématique à cause des marges inexistantes sur les pages suivantes.

cf #19 
