### PR TITLE
Erreur d'accord dans le document de demande de mise à jour de prénom/civilité

### DIFF
--- a/src/documents-templates/DemandeMaj.vue
+++ b/src/documents-templates/DemandeMaj.vue
@@ -55,7 +55,7 @@ const { renderValue, genderSwitch, renderWithGender } = useDocumentTemplate(p)
     </template>
   </p>
   <p v-if="data['changementDemandé'] != 'civilité'">
-    Je suis connue de vos services sous le nom de
+    Je suis {{ renderWithGender('connu', 'civilité') }} de vos services sous le nom de
     {{ renderValue('deadname') }}
     {{ renderValue('nom').toUpperCase() }}.
   </p>


### PR DESCRIPTION
Remonté sur [le pad](https://hackmd.io/STFTm-N2ScyF3SvoJRiOzg) : 

> Erreur d'accord sur https://administrans.fr/documents/demande-maj?organisme=cpam : la phrase "Je suis connue de vos services sous le nom de" reste accordée au féminin ("connue") quelle que soit la civilité sélectionnée, alors qu'elle devrait passer au masculin si on sélectionne "Monsieur".

Ce patch résout le problème.