### PR TITLE
Mise à jour des dépendances du workflow

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -13,13 +13,13 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
           cache: 'yarn'


### PR DESCRIPTION
L’image `Ubuntu 20.04` utilisée dans le workflow GitHub Actions va être non supportée bientôt, cf l’annonce :

https://github.com/actions/runner-images/issues/11101

Ce patch la met à jour vers la version `24.04`.

Au passage, le patch met aussi à jour `checkout` et `setup-node`.

(J’ai essayé de ne pas introduire de changements cassants mais je n’ai pas testé. :s)