### PR TITLE
Mise à jour vers la v4 du cerfa de changement de prénom

### DIFF
--- a/src/documents-templates/RequetePrenomMairie.vue
+++ b/src/documents-templates/RequetePrenomMairie.vue
@@ -11,7 +11,7 @@ const { renderValue, renderDate } = useDocumentTemplate(p)
     <div class="text--center">
       <h1>Demande de changement de prénom</h1>
       <p>
-        Cerfa N° 16233*03 <br>
+        Cerfa N° 16233*04 <br>
         (Article 60 du code civil)
       </p>
     </div>
@@ -182,33 +182,6 @@ const { renderValue, renderDate } = useDocumentTemplate(p)
           </p>
           <hr class="hidden">
         </template>
-        <p>
-          <strong>Acte de mariage du/des enfant(s) (le cas échéant)</strong>
-        </p>
-        <template v-for="row, idx in textToArrays(data.enfants, ',', 3)" :key="idx">
-          <p class="field">
-            Nom du {{ idx + 1}}<template v-if="idx === 0">er</template><template v-else>ème</template> enfant :
-            <span class="value" v-if="row.length > 0 && data.majActeMariageEnfants">
-              {{ row[0] }}
-            </span>
-            <span class="value" v-else></span>
-          </p>
-          <p class="field">
-            Prénom(s) :
-            <span class="value" v-if="row.length > 0 && data.majActeMariageEnfants">
-              {{ row[1] }}
-            </span>
-            <span class="value" v-else></span>
-          </p>
-          <p class="field">
-            Date et lieu de naissance :
-            <span class="value" v-if="row.length > 0 && data.majActeMariageEnfants">
-              {{ row[2] }} à {{ row[3] }}
-            </span>
-            <span class="value" v-else></span>
-          </p>
-          <hr class="hidden">
-        </template>
       </div>
     </div>
     <h2>Attestation sur l'honneur</h2>
@@ -239,12 +212,11 @@ const { renderValue, renderDate } = useDocumentTemplate(p)
         comme non valides et leur présentation ne permettra pas de justifier de votre identité.
       </p>
       <p>
-        A la réception de la notification de votre changement de prénom, vous devez attendre que la
+        À la réception de la notification de votre changement de prénom, vous devez attendre que la
         mise à jour des actes de l’état civil concernés par votre changement de prénom a été
         effectuée. Lorsque cette mise à jour aura été effectuée, vous devrez vous rapprocher de la
         mairie de votre choix pour déposer une demande de renouvellement de votre carte nationale
-        d’e d’un titre d’identité qui ne correspond pas à votre état civil est passible des sanctions
-        prévueidentité et/ou de votre passeport, même si leur durée de validité n’est pas expirée, en
+        d’identité et/ou de votre passeport, même si leur durée de validité n’est pas expirée, en
         justifiant notamment de l’acte de naissance modifié.
       </p>
       <p>

--- a/src/documents.js
+++ b/src/documents.js
@@ -509,13 +509,9 @@ Preuves de refus de changement de la part d'organismes tiers`
         type: 'checkbox',
         name: `Demander une mise à jour de l'acte de naissance de vos enfants`
       }),
-      field('majActeMariageEnfants', {
-        type: 'checkbox',
-        name: `Demander une mise à jour de l'acte de mariage de vos enfants`
-      }),
       field('enfants', {
         name: `Informations sur vos enfants`,
-        showCondition: (data) => {return data.majActeMariageEnfants || data.majActeNaissanceEnfants },
+        showCondition: (data) => {return !!data.majActeNaissanceEnfants },
         type: 'textarea',
         placeholder: 'Lund, Élise, 05/09/2021, Marseille (13)',
         help: `Un·e enfant par ligne, séparer le nom, prénom, date de naissance et lieu de naissance par une virgule`,


### PR DESCRIPTION
Reçu ce jour en privé : 

> Juste pour info, ils m'ont demandé en mairie de refaire le cerfa parce qu'une nouvelle version est dispo (la 4), j'ai pas vu de différences mais peut-être que tu voudras modifier le générateur si tu as le temps

J'ai regardé et a priori les seules choses qui changent c'est : 

1. Le numéro de version : 16233-3 vers 16233-4 : mis à jour
2. Le wording d'une phrase dans les infos de la dernière page : mis à jour
3. l'ajout d'une mention "Ce document est émis par le ministère de la Justice." : j'ai rien touché parce que c'est notre version du document donc je voudrai pas que ça nous soit reproché.

Il y a avait aussi une petite typo dans notre doc que j'ai corrigée, et un accent qui manquait. 

SI quelqu'un peut vérifier en lisant la version 4 du  cerfa et celle ci cote à cote pour vérifier que le contenu textuel et la structure matchent, ça serait top :ok_hand: 

Pour référence, vous pouvez regarder une copie du nouveau doc, téléchargé le 25/03/2025 depuis https://www.service-public.fr/particuliers/vosdroits/R63177 : [cerfa_16233-04.pdf](https://github.com/user-attachments/files/19454581/cerfa_16233-04.pdf)
